### PR TITLE
Added color fix for <strong> tags

### DIFF
--- a/dae.css
+++ b/dae.css
@@ -161,3 +161,26 @@ section.title-slide-v2023 h2 {
   padding: 10px;
   padding-left:20px;
 }
+
+section strong{
+  color: var(--title-color);
+}
+section h1 strong{
+  color: var(--title-color);
+  font-weight: 800;
+}
+section h6 strong{
+  color: var(--title-color);
+}
+section h2 strong{
+  color: var(--title-color);
+}
+section h3 strong{
+  color: var(--title-color);
+}
+section h4 strong{
+  color: var(--title-color);
+}
+section h5 strong{
+  color: var(--title-color);
+}


### PR DESCRIPTION
Markdown in h2 - h5 using **strong** were showing up as blue, This fix will show the bold text in red.

![image](https://user-images.githubusercontent.com/122785950/227653107-4667a5a9-4e44-46b0-a75c-ac201cc69d14.png)
